### PR TITLE
Adds in support for jrpc RequestDoers

### DIFF
--- a/address_test.go
+++ b/address_test.go
@@ -260,7 +260,7 @@ func TestAddress(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	c := NewClient()
+	c := NewClient(nil, nil)
 	t.Run("Save/Fs", func(t *testing.T) {
 		err := fs.Save(c)
 		assert.NoError(t, err)

--- a/client.go
+++ b/client.go
@@ -24,20 +24,18 @@ package factom
 
 import (
 	"fmt"
-	"time"
-
-	jrpc "github.com/AdamSLevy/jsonrpc2/v11"
+	jrpc "github.com/AdamSLevy/jsonrpc2/v12"
 )
 
 // Client makes RPC requests to factomd's and factom-walletd's APIs.  Client
 // embeds two jsonrpc2.Clients, and thus also two http.Client, one for requests
-// to factomd and one for requests to factom-walletd.  Use jsonrpc2.Client's
+// to factomd and one for requests to facgo butom-walletd.  Use jsonrpc2.Client's
 // BasicAuth settings to set up BasicAuth and http.Client's transport settings
 // to configure TLS.
 type Client struct {
-	Factomd       jrpc.Client
+	Factomd       *jrpc.Client
 	FactomdServer string
-	Walletd       jrpc.Client
+	Walletd       *jrpc.Client
 	WalletdServer string
 }
 
@@ -50,10 +48,11 @@ const (
 // NewClient returns a pointer to a Client initialized with the default
 // localhost endpoints for factomd and factom-walletd, and 15 second timeouts
 // for each of the http.Clients.
-func NewClient() *Client {
+func NewClient(factomDoer, walletDoer jrpc.RequestDoer) *Client {
 	c := &Client{FactomdServer: FactomdDefault, WalletdServer: WalletdDefault}
-	c.Factomd.Timeout = 20 * time.Second
-	c.Walletd.Timeout = 10 * time.Second
+
+	c.Factomd = jrpc.NewClient(factomDoer)
+	c.Walletd = jrpc.NewClient(walletDoer)
 	return c
 }
 

--- a/dblock_eblock_entry_test.go
+++ b/dblock_eblock_entry_test.go
@@ -35,7 +35,7 @@ var courtesyNode = "https://courtesy-node.factom.com"
 
 func TestDataStructures(t *testing.T) {
 	height := uint32(166587)
-	c := NewClient()
+	c := NewClient(nil, nil)
 	//c.Factomd.DebugRequest = true
 	db := &DBlock{}
 	db.Header.Height = height

--- a/eblock.go
+++ b/eblock.go
@@ -31,7 +31,7 @@ import (
 	"time"
 
 	merkle "github.com/AdamSLevy/go-merkle"
-	jrpc "github.com/AdamSLevy/jsonrpc2/v11"
+	jrpc "github.com/AdamSLevy/jsonrpc2/v12"
 )
 
 // EBlock represents a Factom Entry Block.

--- a/entry_test.go
+++ b/entry_test.go
@@ -27,7 +27,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/AdamSLevy/jsonrpc2/v11"
+	"github.com/AdamSLevy/jsonrpc2/v12"
 	. "github.com/Factom-Asset-Tokens/factom"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -130,7 +130,7 @@ func TestEntry(t *testing.T) {
 	ec, _ := NewECAddress(ecAddressStr)
 	chainID := ChainID([]Bytes{Bytes(ec[:])})
 	t.Run("ComposeCreate", func(t *testing.T) {
-		c := NewClient()
+		c := NewClient(nil, nil)
 		es, err := ec.GetEsAddress(c)
 		if _, ok := err.(jsonrpc2.Error); ok {
 			// Skip if the EC address is not in the wallet.
@@ -168,7 +168,7 @@ func TestEntry(t *testing.T) {
 		fmt.Println("Chain ID: ", e.ChainID)
 	})
 	t.Run("Create", func(t *testing.T) {
-		c := NewClient()
+		c := NewClient(nil, nil)
 		c.Factomd.DebugRequest = true
 		c.Walletd.DebugRequest = true
 		balance, err := ec.GetBalance(c)

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,9 @@ go 1.13
 
 require (
 	github.com/AdamSLevy/go-merkle v0.0.0-20190611101253-ca33344a884d
+	github.com/AdamSLevy/jsonrpc2 v2.0.0+incompatible
 	github.com/AdamSLevy/jsonrpc2/v11 v11.3.2
+	github.com/AdamSLevy/jsonrpc2/v12 v12.0.0
 	github.com/Factom-Asset-Tokens/base58 v0.0.0-20181227014902-61655c4dd885
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/stretchr/testify v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,11 @@
 github.com/AdamSLevy/go-merkle v0.0.0-20190611101253-ca33344a884d h1:FWutTJGVqBnL4rLgeNaspUYnmnvkXcmDA3QO3rHBGgU=
 github.com/AdamSLevy/go-merkle v0.0.0-20190611101253-ca33344a884d/go.mod h1:Nw3sh5L40Xs1wno7ndbD/dYWg+vARpBvpX9Zz1YSxbo=
+github.com/AdamSLevy/jsonrpc2 v2.0.0+incompatible h1:ut4YIGFeO2Mzyj7pNEmcHBAm/88qCDmZMyUn6EeuXI4=
+github.com/AdamSLevy/jsonrpc2 v2.0.0+incompatible/go.mod h1:6enYNa3tk//n6m8F7zXGhRbtTqpSeysaUcwZbLIHGYQ=
 github.com/AdamSLevy/jsonrpc2/v11 v11.3.2 h1:McSW/pP7K0/Ucjig6AJwW7Khph/XOMYhSB8v3YxMBl4=
 github.com/AdamSLevy/jsonrpc2/v11 v11.3.2/go.mod h1:7fNjH6BXM0KVswWqj+K/mnOS8wiSke0sE8X46hS+nsc=
+github.com/AdamSLevy/jsonrpc2/v12 v12.0.0 h1:2CO5yc4+4cfm6rvLl4pVPqaNLqbdHkcchK15p3aFxkg=
+github.com/AdamSLevy/jsonrpc2/v12 v12.0.0/go.mod h1:sE4iA2g7QxE9xbNXpijPrdZrhmB9hJript+gL+ZzUS4=
 github.com/Factom-Asset-Tokens/base58 v0.0.0-20181227014902-61655c4dd885 h1:rfy2fwMrOZPqQgjsH7VCreGMSPzcvqQrfjeSs8nf+sY=
 github.com/Factom-Asset-Tokens/base58 v0.0.0-20181227014902-61655c4dd885/go.mod h1:RVXsRSp6VzXw5l1uiGazuf3qo23Qk0h1HzMcQk+X4LE=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/heights_test.go
+++ b/heights_test.go
@@ -31,7 +31,7 @@ import (
 func TestHeights(t *testing.T) {
 	var h Heights
 	assert := assert.New(t)
-	c := NewClient()
+	c := NewClient(nil, nil)
 	err := h.Get(c)
 	assert.NoError(err)
 	zero := uint32(0)

--- a/identity_test.go
+++ b/identity_test.go
@@ -210,7 +210,7 @@ var identityTests = []struct {
 
 var factomServer = "https://courtesy-node.factom.com"
 
-var c = NewClient()
+var c = NewClient(nil, nil)
 
 func TestIdentity(t *testing.T) {
 	for _, test := range identityTests {

--- a/pendingentries_test.go
+++ b/pendingentries_test.go
@@ -42,7 +42,7 @@ var searchID = NewBytes32FromString(
 // verified.
 func TestPendingEntries(t *testing.T) {
 	var pe PendingEntries
-	c := NewClient()
+	c := NewClient(nil, nil)
 	//c.Factomd.DebugRequest = true
 	assert := assert.New(t)
 	require := require.New(t)


### PR DESCRIPTION
When a Client object is created, you can specify a requestDoer object.

This permits (for instance) retryable HTTP clients instead of the default HTTP Client,
 and for quick switching between clients in the future.