### PR TITLE
Add RCD validate flags

### DIFF
--- a/address.go
+++ b/address.go
@@ -428,7 +428,7 @@ func sha256d(data []byte) [sha256.Size]byte {
 
 // RCD computes the RCD for adr.
 func (adr FsAddress) RCD() []byte {
-	return append([]byte{RCDType01}, adr.PublicKey()[:]...)
+	return append([]byte{byte(RCDType01)}, adr.PublicKey()[:]...)
 }
 
 // Sign the msg.

--- a/fat103/sign.go
+++ b/fat103/sign.go
@@ -10,11 +10,7 @@ import (
 	"github.com/Factom-Asset-Tokens/factom/jsonlen"
 )
 
-var rng *rand.Rand
-
-func init() {
-	rng = rand.New(rand.NewSource(time.Now().UnixNano()))
-}
+var rng = rand.New(rand.NewSource(time.Now().UnixNano()))
 
 // Sign the RCD/Sig ID Salt + Timestamp Salt + Chain ID Salt + Content of the
 // factom.Entry and add the RCD + signature pairs for the given addresses to

--- a/fat103/validate.go
+++ b/fat103/validate.go
@@ -35,7 +35,8 @@ import (
 // Validate validates the structure of the ExtIDs of the factom.Entry to make
 // sure that it has a valid timestamp salt and a valid set of RCD/signature
 // pairs.
-func Validate(e factom.Entry, expected map[factom.Bytes32]struct{}, flag int) error {
+func Validate(e factom.Entry, expected map[factom.Bytes32]struct{},
+	whitelist ...factom.RCDType) error {
 	if len(expected) == 0 || len(e.ExtIDs) != 2*len(expected)+1 {
 		return fmt.Errorf("invalid number of ExtIDs")
 	}
@@ -81,7 +82,7 @@ func Validate(e factom.Entry, expected map[factom.Bytes32]struct{}, flag int) er
 		sig := rcdSigs[i+1]
 		msgHash := sha512.Sum512(msg[start:])
 
-		rcdHash, err := factom.ValidateRCD(rcd, sig, msgHash[:], flag)
+		rcdHash, err := factom.ValidateRCD(rcd, sig, msgHash[:], whitelist...)
 		if err != nil {
 			return fmt.Errorf("ExtIDs[%v]: %w", i+1, err)
 		}

--- a/fat103/validate.go
+++ b/fat103/validate.go
@@ -35,7 +35,7 @@ import (
 // Validate validates the structure of the ExtIDs of the factom.Entry to make
 // sure that it has a valid timestamp salt and a valid set of RCD/signature
 // pairs.
-func Validate(e factom.Entry, expected map[factom.Bytes32]struct{}) error {
+func Validate(e factom.Entry, expected map[factom.Bytes32]struct{}, flag int) error {
 	if len(expected) == 0 || len(e.ExtIDs) != 2*len(expected)+1 {
 		return fmt.Errorf("invalid number of ExtIDs")
 	}
@@ -81,7 +81,7 @@ func Validate(e factom.Entry, expected map[factom.Bytes32]struct{}) error {
 		sig := rcdSigs[i+1]
 		msgHash := sha512.Sum512(msg[start:])
 
-		rcdHash, err := factom.ValidateRCD(rcd, sig, msgHash[:])
+		rcdHash, err := factom.ValidateRCD(rcd, sig, msgHash[:], flag)
 		if err != nil {
 			return fmt.Errorf("ExtIDs[%v]: %w", i+1, err)
 		}

--- a/idkey.tmpl
+++ b/idkey.tmpl
@@ -179,7 +179,7 @@ func (key SK{{.ID}}Key) ID{{.ID}}Key() ID{{.ID}}Key {
 
 // RCD computes the RCD for key.
 func (key SK{{.ID}}Key) RCD() []byte {
-	return append([]byte{RCDType01}, key.PublicKey()[:]...)
+	return append([]byte{byte(RCDType01)}, key.PublicKey()[:]...)
 }
 
 // Sign the msg.

--- a/idkey_gen.go
+++ b/idkey_gen.go
@@ -187,7 +187,7 @@ func (key SK1Key) ID1Key() ID1Key {
 
 // RCD computes the RCD for key.
 func (key SK1Key) RCD() []byte {
-	return append([]byte{RCDType01}, key.PublicKey()[:]...)
+	return append([]byte{byte(RCDType01)}, key.PublicKey()[:]...)
 }
 
 // Sign the msg.
@@ -337,7 +337,7 @@ func (key SK2Key) ID2Key() ID2Key {
 
 // RCD computes the RCD for key.
 func (key SK2Key) RCD() []byte {
-	return append([]byte{RCDType01}, key.PublicKey()[:]...)
+	return append([]byte{byte(RCDType01)}, key.PublicKey()[:]...)
 }
 
 // Sign the msg.
@@ -487,7 +487,7 @@ func (key SK3Key) ID3Key() ID3Key {
 
 // RCD computes the RCD for key.
 func (key SK3Key) RCD() []byte {
-	return append([]byte{RCDType01}, key.PublicKey()[:]...)
+	return append([]byte{byte(RCDType01)}, key.PublicKey()[:]...)
 }
 
 // Sign the msg.
@@ -637,7 +637,7 @@ func (key SK4Key) ID4Key() ID4Key {
 
 // RCD computes the RCD for key.
 func (key SK4Key) RCD() []byte {
-	return append([]byte{RCDType01}, key.PublicKey()[:]...)
+	return append([]byte{byte(RCDType01)}, key.PublicKey()[:]...)
 }
 
 // Sign the msg.

--- a/rcdsigner.go
+++ b/rcdsigner.go
@@ -27,19 +27,6 @@ import (
 	"fmt"
 )
 
-// TODO: What would be the best naming for this constants?
-const (
-	// Flags are set to indicate which rcds are valid for the validate
-	// function. This allows a whitelist of valid rcd types for
-	// the validate function. The flags are a bitmask to be combined with
-	// a bitwise OR, e.g:
-	//		R_RCD1|R_RCDe
-	//
-
-	R_ALL = 1 << iota // Indicates all rcd types are valid
-	R_RCD1
-)
-
 // RCDSigner is the interface implemented by types that can generate Redeem
 // Condition Datastructures and the corresponding signatures to validate them.
 type RCDSigner interface {
@@ -50,35 +37,45 @@ type RCDSigner interface {
 	Sign(msg []byte) []byte
 }
 
-func ValidateRCD(rcd, sig, msg []byte, flag int) (Bytes32, error) {
+type RCDType byte
+
+func (r RCDType) String() string {
+	return fmt.Sprintf("RCDType%02x")
+}
+
+// ValidateRCD validates the rcd against the sig and msg. If a whitelist is
+// provided, then only those RCDTypes will be accepted. All other RCDTypes will
+// return "RCDTypeX not accepted". Omitting the whitelist allows all RCDTypes.
+func ValidateRCD(rcd, sig, msg []byte, whitelist ...RCDType) (Bytes32, error) {
 	if len(rcd) < 1 {
 		return Bytes32{}, fmt.Errorf("invalid RCD size")
 	}
+	rcdType := RCDType(rcd[0])
 	var validateRCD func(rcd, sig, msg []byte) (Bytes32, error)
 
-	// Validate the rcd type is an accepted type based on the flag.
-	// If `mask & flag` > 0, the rcd is enabled.
-	// We always check the R_ALL bit
-	mask := R_ALL
+	if len(whitelist) > 0 {
+		whitemap := make(map[RCDType]struct{}, len(whitelist))
+		for _, rcdType := range whitelist {
+			whitemap[rcdType] = struct{}{}
+		}
+		if _, ok := whitemap[rcdType]; !ok {
+			return Bytes32{}, fmt.Errorf("%v not accepted", rcdType)
+		}
+	}
 
-	switch rcd[0] {
+	switch RCDType(rcd[0]) {
 	case RCDType01:
-		// Also check the rcd01 bit
-		mask = mask | R_RCD1
 		validateRCD = ValidateRCD01
 	default:
 		return Bytes32{}, fmt.Errorf("unsupported RCD")
 	}
 
-	if flag&mask == 0 {
-		return Bytes32{}, fmt.Errorf("rcd type is rejected by the validate mask")
-	}
 	return validateRCD(rcd, sig, msg)
 }
 
 const (
 	// RCDType is the magic number identifying the currenctly accepted RCD.
-	RCDType01 byte = 0x01
+	RCDType01 RCDType = 0x01
 	// RCDSize is the size of the RCD.
 	RCDType01Size = ed25519.PublicKeySize + 1
 	// SignatureSize is the size of the ed25519 signatures.
@@ -89,7 +86,7 @@ func ValidateRCD01(rcd, sig, msg []byte) (Bytes32, error) {
 	if len(rcd) != RCDType01Size {
 		return Bytes32{}, fmt.Errorf("invalid RCD size")
 	}
-	if rcd[0] != RCDType01 {
+	if RCDType(rcd[0]) != RCDType01 {
 		return Bytes32{}, fmt.Errorf("invalid RCD type")
 	}
 	if len(sig) != RCDType01SigSize {


### PR DESCRIPTION
We should have a bitwise flag that indicates which rcd types are valid. I included a `R_ALL` flag to indicate all rcd types are valid.

I am unsure where the best place for the constants are, or the best naming. The os package uses flags like:
```
os.O_RDONLY
```
I like the `O_` syntax, as it's easy for IDE to autocomplete if you know the prefix.